### PR TITLE
Add SSM parameter resolution in config when using CLI, expand docs and fix issues in Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The configuration reference for node-db-migrate package can be found [here](http
 The configuration is extended to resolve values stored in the AWS SSM Parameter store and environment variables instead of storing them in the config file.
 The values are resolved by using the CLI when `read-local-config` option
 
-Currently the values can referenced by environment variables or from SSM Paramter store.
+Currently the values can referenced by environment variables or from SSM Parameter store.
 
 In the following example,
  -  `user` and `password` will be resolved 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # sls-db-migrations
-Serverless wrapper for node.js db-migrations framework
+Serverless wrapper for [node-db-migrate](https://github.com/db-migrate/node-db-migrate) framework
 
 ## Contents
 - [Quick Start](#quick-start)
@@ -7,13 +7,25 @@ Serverless wrapper for node.js db-migrations framework
 
 ## What is this?
 
-`sls-db-migrations` is a wrapper around the [node-db-migrate](https://github.com/db-migrate/node-db-migrate) framework designed to
-work when deployed in a serverless function.
+`sls-db-migrations` is a wrapper around the [node-db-migrate](https://github.com/db-migrate/node-db-migrate) framework, a database migrations framework, designed to work when deployed in a serverless function.  
 
 This repo contains the code for the AWS Lambda and a CLI tool to invoke this Lambda.
 The migrations are stored as a ZIP file in AWS S3 and the Lambda uses these to run the database migration commands
 
-## <a name="quick-start"></a>Quick Start
+### ZIP Archive Structure
+
+The ZIP file containing the migrations stored in S3 should have a folder named `migrations` at the root level and optionally, the configuration JSON can be included.
+
+Example:
+
+```bash
+$ zip -sf migrations.zip 
+Archive contains:
+  database.json
+  migrations/
+```
+
+## Quick Start
 
 ### Deploying the AWS Lambda
 
@@ -47,19 +59,86 @@ Runs the migration of the files stored in the S3 bucket `db-migrations` in the p
 using the config `database.json` from the local directory. `read-local-config` flag specifies to use the config from local system rather than the one 
 packaged in the ZIP file 
 
-## Zip Archive Structure
 
-The ZIP file stored in S3 should have a folder named `migrations` at the root level and optionally, the configuration JSON can be included.
+## Configuration
 
-Example:
+The configuration reference for node-db-migrate package can be found [here](https://db-migrate.readthedocs.io/en/latest/Getting%20Started/configuration/)
 
-```bash
-$ zip -sf migrations.zip 
-Archive contains:
-  database.json
-  migrations/
+The configuration is extended to resolve values stored in the AWS SSM Parameter store and environment variables instead of storing them in the config file.
+The values are resolved by using the CLI when `read-local-config` option
+
+Currently the values can referenced by environment variables or from SSM Paramter store.
+
+In the following example,
+ -  `user` and `password` will be resolved 
+from the SSM Parameter store,
+ - `host` and `database` will be 
+resolved from the environment variables 
+- `driver` will be remain unchanged.
+
+```json
+{
+  "prod":{
+    "driver": "mysql",
+    "user": { "SSM": "/prod/db/migrationsuser"},
+    "password": { "SSM": "/prod/db/migrationsuserpassword"},
+    "database": { "ENV": "db"},
+    "host": { "ENV": "host"},
+  }
+}
 ```
+
 
 ## Examples
 
-A complete example with a script that zips and uploads files to S3 and invokes the Lambda can be found in the  [examples/basic](./examples/basic) directory.
+A complete example with a script that zips and uploads files to S3 and invokes the Lambda can be found in the [examples/basic](./examples/basic) directory.
+
+## Reference
+
+### CLI
+The `sls-dbmigrate` command is used to invoke the deployed AWS Lambda 
+for running the migrations.
+The CLI takes care of constructing and resolving any dynamic values in 
+the configuration.
+
+```
+ sls-dbmigrate [options] [command]
+```
+
+- Supported commands
+    - `up` - Runs the up migrations for the given environment. The count or specification upto which the migration is to be run can be specified.  
+    Eg: `sls-dbmigrate up <env> [countOrSpecification] [options] `
+
+    - `down` - Runs the down migrations for the given environment. The count or specification upto which the migration is to be run can be specified.  
+    Eg: `sls-dbmigrate down <env> [countOrSpecification] [options] `
+
+- Options  
+  (The options written here are currently common for both the commands `up`  and `down`)
+    - `-l --lambda <arn or name>` - the ARN or name of the Lambda function
+    - `--bucket <bucket name>` - the S3 bucket where migrations are stored
+    - `--archive-path <path/to/migrate.zip>` the file path inside the     bucket to the migration archive
+    - `--config-path <path/to/database.json>` -  the file path inside the migration archive or in the local system.
+    - `--read-local-config` -  Optional. if specified, then the config is read from specified `config-path` in the local system where CLI is used. This takes precedence over the zipped database.json.
+    The configuration is also resolved for dynamic values locally
+
+
+### Lambda payload
+
+This is provided here for a reference.
+It is recommended to use the CLI tool for invoking the Lambda.
+
+```ts
+
+{
+  bucket: string, // the S3 bucket where the migrations zip is stored
+  archivePath: string, // the path inside the bucket to the ZIP file
+  command: "up" | "down" | "reset",
+  configOptions: {
+    config: string | {}, // The path inside the ZIP or configuration JSON
+                        // object directly, default will be database.json
+    env: string, // The environment to use in the configuration.
+  }
+  commandOptions: {} // the options specific to a command.
+}
+
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 Serverless wrapper for [node-db-migrate](https://github.com/db-migrate/node-db-migrate) framework
 
 ## Contents
-- [Quick Start](#quick-start)
+
+  * [What is this?](#what-is-this-)
+  * [Quick Start](#quick-start)
+    + [Deploying the AWS Lambda](#deploying-the-aws-lambda)
+    + [Using the CLI tool](#using-the-cli-tool)
+  * [ZIP Archive Structure](#zip-archive-structure)
+  * [Configuration](#configuration)
+  * [Examples](#examples)
+  * [Reference](#reference)
+    + [CLI](#cli)
+    + [Lambda payload](#lambda-payload)
 
 
 ## What is this?
@@ -12,18 +22,6 @@ Serverless wrapper for [node-db-migrate](https://github.com/db-migrate/node-db-m
 This repo contains the code for the AWS Lambda and a CLI tool to invoke this Lambda.
 The migrations are stored as a ZIP file in AWS S3 and the Lambda uses these to run the database migration commands
 
-### ZIP Archive Structure
-
-The ZIP file containing the migrations stored in S3 should have a folder named `migrations` at the root level and optionally, the configuration JSON can be included.
-
-Example:
-
-```bash
-$ zip -sf migrations.zip 
-Archive contains:
-  database.json
-  migrations/
-```
 
 ## Quick Start
 
@@ -49,16 +47,35 @@ npm run deploy
 
 ### Using the CLI tool
 
+1. Install the package
+```
+npm install git://github.com/senor-coder/sls-db-migrations.git#main
+```
+
+2. Run the CLI command
 ```bash
 sls-dbmigrate up --lambda <name or ARN>
    --bucket db-migrations
    --archive-path auth/migrations.zip 
    --config-path database.json --read-local-config prod
 ```
-Runs the migration of the files stored in the S3 bucket `db-migrations` in the path `auth/migrations.zip` using the environment `prod` 
+The above command runs the migration of the files stored in the S3 bucket `db-migrations` in the path `auth/migrations.zip` using the environment `prod` 
 using the config `database.json` from the local directory. `read-local-config` flag specifies to use the config from local system rather than the one 
 packaged in the ZIP file 
 
+
+## ZIP Archive Structure
+
+The ZIP file containing the migrations stored in S3 should have a folder named `migrations` at the root level and optionally, the configuration JSON can be included.
+
+Example:
+
+```bash
+$ zip -sf migrations.zip 
+Archive contains:
+  database.json
+  migrations/
+```
 
 ## Configuration
 

--- a/bin/sls-dbmigrate.js
+++ b/bin/sls-dbmigrate.js
@@ -5,7 +5,7 @@ const { LambdaClient, InvokeCommand, InvokeCommandInput } = require('@aws-sdk/cl
 const fs = require('fs');
 const ConfigResolver = require('../lib/configResolver');
 const { EnvironmentValueResolver } = require('../lib/configResolver/environment');
-const { SSMParamterValueResolver } = require('../lib/configResolver/ssm');
+const { SSMParameterValueResolver } = require('../lib/configResolver/ssm');
 const { SSMClient } = require('@aws-sdk/client-ssm');
 
 
@@ -62,8 +62,8 @@ const readLocalConfigFromPath = async (path) => {
     const environmentValueResolver = new EnvironmentValueResolver();
 
     const ssmClient = new SSMClient();
-    const ssmParamterValueResolver = new SSMParamterValueResolver(ssmClient);
-    const configResolver = new ConfigResolver([environmentValueResolver, ssmParamterValueResolver]);
+    const ssmParameterValueResolver = new SSMParameterValueResolver(ssmClient);
+    const configResolver = new ConfigResolver([environmentValueResolver, ssmParameterValueResolver]);
 
     const resolvedConfig = await configResolver.resolveConfig(config);
     return resolvedConfig

--- a/bin/sls-dbmigrate.js
+++ b/bin/sls-dbmigrate.js
@@ -104,7 +104,7 @@ addCommonOptions(up)
             await handleLambdaResponse(invokeCommandOutput)
             console.log('Done.')
         } catch (e) {
-            console.log(error)
+            console.log(e)
             process.exitCode = LAMBDA_FAILURE_EXIT_CODE
             process.exit(LAMBDA_FAILURE_EXIT_CODE)
         }

--- a/bin/sls-dbmigrate.js
+++ b/bin/sls-dbmigrate.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const ConfigResolver = require('../lib/configResolver');
 const { EnvironmentValueResolver } = require('../lib/configResolver/environment');
 const { SSMParamterValueResolver } = require('../lib/configResolver/ssm');
+const { SSMClient } = require('@aws-sdk/client-ssm');
 
 
 const LAMBDA_FAILURE_EXIT_CODE = 2;
@@ -59,7 +60,9 @@ const readLocalConfigFromPath = async (path) => {
 
     const config = JSON.parse(fs.readFileSync(path, 'utf8'));
     const environmentValueResolver = new EnvironmentValueResolver();
-    const ssmParamterValueResolver = new SSMParamterValueResolver();
+
+    const ssmClient = new SSMClient();
+    const ssmParamterValueResolver = new SSMParamterValueResolver(ssmClient);
     const configResolver = new ConfigResolver([environmentValueResolver, ssmParamterValueResolver]);
 
     const resolvedConfig = await configResolver.resolveConfig(config);

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,66 @@
+# Basic Example
+
+This is a simple example of how to use sls-db-migrations along 
+with the node-db-migrate for performing schema migrations for your database.
+
+This example assumes that you already have the Lambda deployed
+and covers how the Lambda can be used.
+
+## Folder structure
+
+```bash
+.
+├── dbmigration
+│   ├── database.json 
+│   └── migrations
+│       ├── 20210717101554-init.js
+│       ├── package.json
+│       └── sqls
+│           ├── 20210717101554-init-down.sql
+│           └── 20210717101554-init-up.sql
+├── README.md
+└── script.sh
+
+```
+
+## Quick overview
+
+- The `dbmigration/migrations` folder has the migration files generated through the `node-db-migrate` CLI. 
+- `script.sh` covers how to ZIP this example, upload to S3 and invoke the Lambda to perform the migrations
+
+## Creating migrations
+
+If you're not familiar with what database schema migrations are and the [node-db-migrate](https://github.com/db-migrate/node-db-migrate) framework, it is recommended that you read about them before continuing.
+
+1. Install the `node-db-migrate` package
+```
+yarn add --save-dev db-migrate db-migrate-mysql 
+```
+
+2. Create a `database.json` with the basic configuration
+```json
+{
+  "prod": {
+    "driver": "mysql",
+    "user": "admin",
+    "password": "abcd",
+    "host": "localhost",
+    "database": "sandbox",
+    "port": 3307,
+    "multipleStatements": true
+  },
+  "sql-file": true
+}
+```
+
+2. To create a migration, use `db-migrate create "init" --env prod`. This doesn't actually connect to the database, but just creates the necessary template files for writing migrations. 
+The reference for the db-migrate command can be found [here](https://db-migrate.readthedocs.io/en/latest/Getting%20Started/commands/#create)
+
+3. Edit the up and down SQL files under `migrations/sqls/`
+
+## Running migrations
+
+To use the Lambda for running these migrations, first zip the `migrations` directory and upload to S3.
+Use the sls-dbmigrate CLI tool to invoke the Lambda
+
+See `script.sh` for an example to do this.

--- a/lib/configResolver/environment.js
+++ b/lib/configResolver/environment.js
@@ -1,0 +1,58 @@
+const ConfigKeyReferenceError = require('./errors.js');
+
+/**
+ * Resolves values from the environment variables
+ * {"ENV":"host"} will replaced by the value of "host" from the environment 
+ */
+class EnvironmentValueResolver {
+    static ENV_KEY = "ENV";
+
+    keynameToResolve(o) {
+        if(o === undefined || o === null || !typeof(o) === 'object') return null;
+
+        const keys = Object.keys(o)
+        if (keys.length === 1 && keys[0] === EnvironmentValueResolver.ENV_KEY)
+            return o.ENV
+
+        return null;
+    }
+    key() {
+        return EnvironmentValueResolver.ENV_KEY;
+    }
+    resolveValue(key) {
+        let value = process.env[key]
+        if(process.env[key] === undefined) {
+            value = null
+        }
+        return value
+    }
+
+    traverseAndSetEnvParams(configObject) {
+        let resolvedObject = {};
+        const objectKeys = Object.keys(configObject);
+
+        objectKeys.forEach(key => {
+            let value = configObject[key];
+            const keyName = this.keynameToResolve(configObject[key])
+            if (keyName && !this.resolveValue(keyName)) {
+                // throw new ConfigKeyReferenceError(`${keyName} has no value defined in the environment`)
+            }
+
+            if (keyName) {
+                value = this.resolveValue(keyName)
+            } else if (typeof (configObject[key]) === 'object') {
+                value = this.traverseAndSetEnvParams(configObject[key]);
+            }
+            resolvedObject[key] = value
+        });
+        return resolvedObject;
+    }
+    async resolveConfig(configObject) {
+        let resolvedObject = this.traverseAndSetEnvParams(configObject);
+        return resolvedObject;
+
+    }
+
+}
+
+module.exports = { EnvironmentValueResolver }

--- a/lib/configResolver/environment.js
+++ b/lib/configResolver/environment.js
@@ -35,7 +35,7 @@ class EnvironmentValueResolver {
             let value = configObject[key];
             const keyName = this.keynameToResolve(configObject[key])
             if (keyName && !this.resolveValue(keyName)) {
-                // throw new ConfigKeyReferenceError(`${keyName} has no value defined in the environment`)
+                throw new ConfigKeyReferenceError(`${keyName} has no value defined in the environment`)
             }
 
             if (keyName) {

--- a/lib/configResolver/errors.js
+++ b/lib/configResolver/errors.js
@@ -1,0 +1,5 @@
+class ConfigKeyReferenceError extends Error {
+
+}
+
+module.exports = ConfigKeyReferenceError;

--- a/lib/configResolver/index.js
+++ b/lib/configResolver/index.js
@@ -15,7 +15,6 @@
         let resolvedConfig = {...configObject};
         for (const resolver of this.valueResolvers) {
             resolvedConfig = await resolver.resolveConfig(resolvedConfig);
-            console.log(resolvedConfig)
         }
 
         return resolvedConfig;

--- a/lib/configResolver/index.js
+++ b/lib/configResolver/index.js
@@ -1,0 +1,25 @@
+
+/**
+ * Given a config (similar to db-migrate's config), walks the config object
+ * and resolves any external references (supports SSM currently)
+ */
+ class ConfigResolver {
+    constructor(valueResolvers) {
+        this.valueResolvers = valueResolvers || [];
+    }
+    registerValueResolver(valueResolver) {
+        this.valueResolvers.push(valueResolver)
+    }
+
+    async resolveConfig(configObject) {
+        let resolvedConfig = {...configObject};
+        for (const resolver of this.valueResolvers) {
+            resolvedConfig = await resolver.resolveConfig(resolvedConfig);
+            console.log(resolvedConfig)
+        }
+
+        return resolvedConfig;
+    }
+ }
+
+ module.exports = ConfigResolver;

--- a/lib/configResolver/ssm.js
+++ b/lib/configResolver/ssm.js
@@ -1,0 +1,75 @@
+const ConfigKeyReferenceError = require('./errors.js');
+const { GetParametersCommand, SSMClient } = require('@aws-sdk/client-ssm');
+
+
+class SSMParamterValueResolver {
+    static SSM_KEY = 'SSM'
+    shouldResolveFromSSM(o) {
+        // {SSM: 'paramter-key'}
+        if(o === undefined || o === null || !typeof(o) === 'object') return false;
+        const keys = Object.keys(o)
+        if (keys.length === 1 && keys[0] === SSMParamterValueResolver.SSM_KEY)
+            return o.SSM
+        return false
+    }
+
+
+    async lookupAndResolveParams(parameters) {
+        const client = new SSMClient();
+        const command = new GetParametersCommand({ Names: parameters, WithDecryption: true });
+
+        const parameterResults = await client.send(command);
+
+
+        parameterResults.InvalidParameters.forEach((param) => {
+            const message = `Invalid SSM parameter: ${param}`;
+            throw new ConfigKeyReferenceError(message)
+        });
+
+        const result = {};
+        parameterResults.Parameters.forEach((paramResult) => {
+            result[paramResult.Name] = paramResult.Value;
+        })
+
+        return result
+    }
+    shouldTraverseFurtherDown(value) {
+        return typeof(value) === 'object' && typeof(value) !== undefined  && value !== null;
+    }
+    setParams(o, resolvedValues) {
+        let resolvedObject = {};
+        const objectKeys = Object.keys(o);
+        objectKeys.forEach(key => {
+            let value = o[key];
+            const name = this.shouldResolveFromSSM(o[key])
+            if (name) {
+                value = resolvedValues[name] || null
+            } else if (this.shouldTraverseFurtherDown(o[key])) {
+                value = this.setParams(o[key], resolvedValues);
+            }
+            resolvedObject[key] = value
+        });
+        return resolvedObject;
+
+    }
+    traverseAndGetSSMKeys(o) {
+        const objectKeys = Object.keys(o);
+        const paramsToResolve = [];
+        objectKeys.forEach(key => {
+            const name = this.shouldResolveFromSSM(o[key])
+            if (name) {
+                paramsToResolve.push(name)
+            } else if (this.shouldTraverseFurtherDown(o[key])) {
+                paramsToResolve.push(...this.traverseAndGetSSMKeys(o[key]));
+            }
+        });
+        return paramsToResolve;
+    }
+    async resolveConfig(configObject) {
+        let keysToLookup = this.traverseAndGetSSMKeys(configObject);
+        let lookedupValues = await this.lookupAndResolveParams(keysToLookup);
+        let resolvedConfigObject = this.setParams(configObject, lookedupValues);
+        return resolvedConfigObject
+    }
+}
+module.exports = { SSMParamterValueResolver }

--- a/lib/configResolver/ssm.js
+++ b/lib/configResolver/ssm.js
@@ -26,8 +26,7 @@ class SSMParameterValueResolver {
     async lookupAndResolveParams(parameters) {
         const command = new GetParametersCommand({ Names: parameters, WithDecryption: true });
 
-        const parameterResults = this.ssmClient.send(command);
-
+        const parameterResults = await this.ssmClient.send(command);
 
         parameterResults.InvalidParameters.forEach((param) => {
             const message = `Invalid SSM parameter: ${param}`;

--- a/lib/configResolver/ssm.js
+++ b/lib/configResolver/ssm.js
@@ -4,6 +4,15 @@ const { GetParametersCommand, SSMClient } = require('@aws-sdk/client-ssm');
 
 class SSMParamterValueResolver {
     static SSM_KEY = 'SSM'
+    
+    /**
+     * Constructs an instance of this resolver
+     * @param {SSMClient} ssmClient the SSMClient that will be used for resolving the values
+     */
+    constructor(ssmClient) {
+        this.ssmClient = ssmClient;
+    }
+
     shouldResolveFromSSM(o) {
         // {SSM: 'paramter-key'}
         if(o === undefined || o === null || !typeof(o) === 'object') return false;
@@ -15,10 +24,9 @@ class SSMParamterValueResolver {
 
 
     async lookupAndResolveParams(parameters) {
-        const client = new SSMClient();
         const command = new GetParametersCommand({ Names: parameters, WithDecryption: true });
 
-        const parameterResults = await client.send(command);
+        const parameterResults = this.ssmClient.send(command);
 
 
         parameterResults.InvalidParameters.forEach((param) => {

--- a/lib/configResolver/ssm.js
+++ b/lib/configResolver/ssm.js
@@ -2,7 +2,7 @@ const ConfigKeyReferenceError = require('./errors.js');
 const { GetParametersCommand, SSMClient } = require('@aws-sdk/client-ssm');
 
 
-class SSMParamterValueResolver {
+class SSMParameterValueResolver {
     static SSM_KEY = 'SSM'
     
     /**
@@ -14,10 +14,10 @@ class SSMParamterValueResolver {
     }
 
     shouldResolveFromSSM(o) {
-        // {SSM: 'paramter-key'}
+        // {SSM: 'parameter-key'}
         if(o === undefined || o === null || !typeof(o) === 'object') return false;
         const keys = Object.keys(o)
-        if (keys.length === 1 && keys[0] === SSMParamterValueResolver.SSM_KEY)
+        if (keys.length === 1 && keys[0] === SSMParameterValueResolver.SSM_KEY)
             return o.SSM
         return false
     }
@@ -83,4 +83,4 @@ class SSMParamterValueResolver {
         return configObject;
     }
 }
-module.exports = { SSMParamterValueResolver }
+module.exports = { SSMParameterValueResolver }

--- a/lib/configResolver/ssm.js
+++ b/lib/configResolver/ssm.js
@@ -67,9 +67,12 @@ class SSMParamterValueResolver {
     }
     async resolveConfig(configObject) {
         let keysToLookup = this.traverseAndGetSSMKeys(configObject);
-        let lookedupValues = await this.lookupAndResolveParams(keysToLookup);
-        let resolvedConfigObject = this.setParams(configObject, lookedupValues);
-        return resolvedConfigObject
+        if(keysToLookup && keysToLookup.length > 0) {
+            let lookedupValues = await this.lookupAndResolveParams(keysToLookup);
+            let resolvedConfigObject = this.setParams(configObject, lookedupValues);
+            return resolvedConfigObject    
+        }
+        return configObject;
     }
 }
 module.exports = { SSMParamterValueResolver }

--- a/migration/serverlessDbMigrator.js
+++ b/migration/serverlessDbMigrator.js
@@ -66,7 +66,15 @@ class ServerlessDBMigrator {
         console.log(`Downloaded File to: ${downloadedFile}`);
 
         console.log(`Extracting zip File to: ${targetDir}`);
-        await this.extractArchive(downloadedFile, targetDir);
+        try {
+            await this.extractArchive(downloadedFile, targetDir);
+        } catch (error) {
+            // Reading ZIP files fails occasionally, with errors like "Bad Archive", "Archive read error" etc
+            // This sleep "hack" seems to solve that
+            console.log(`There was an error (${error}) in extracting the zip, retrying extract again`);
+            await new Promise((resolve) => {setTimeout(resolve, 2000);})
+            await this.extractArchive(downloadedFile, targetDir);
+        }
         console.log(`Zip file extracted.`);
 
         await this.baseDbMigrationClient.createDB(targetDir, configOptions);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/client-s3": "^3.22.0",
     "commander": "^8.2.0",
     "db-migrate": "^0.11.12",
-    "db-migrate-mysql": "^2.1.2",
+    "db-migrate-mysql": "2.1.2",
     "node-stream-zip": "^1.13.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.31.0",
     "@aws-sdk/client-s3": "^3.22.0",
+    "@aws-sdk/client-ssm": "^3.33.0",
     "commander": "^8.2.0",
     "db-migrate": "^0.11.12",
     "db-migrate-mysql": "2.1.2",
@@ -35,6 +36,8 @@
     "@babel/core": "^7.15.5",
     "@babel/preset-env": "^7.15.6",
     "babel-register": "^6.26.0",
+    "chai": "^4.3.4",
+    "sinon": "^11.1.2",
     "mocha": "^9.1.1",
     "serverless": "^2.52.0"
   }


### PR DESCRIPTION
- This PR adds a feature to specify AWS SSM Parameter Store parameters, which are resolved by the CLI before invoking the Lambda.
- In addition to that, added docs and a fix for occasional ZIP extraction failure and pin db-migrate-mysql.
