### PR TITLE
Allow specifying region option in the CLI

### DIFF
--- a/bin/sls-dbmigrate.js
+++ b/bin/sls-dbmigrate.js
@@ -81,7 +81,7 @@ const addCommonOptions = (command) => {
 }
 
 const program = new Command();
-program.version('0.0.1')
+program.version('0.1.1')
 
 const up = program.command('up')
     .argument('<env>', 'the environment to use based on the config file in the specified archive')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sls-db-migrations",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "commonjs",
   "description": "Serverless wrapper for node.js db-migrations framework",
   "repository": {


### PR DESCRIPTION
Added an option to specify AWS Region to be use in the CLI requests - currently will be used for the Lambda invokation and SSM parameters resolution
